### PR TITLE
Fix query type

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/unsplash/url-transformers.git"
   },
-  "version": "0.0.3",
+  "version": "0.0.4",
   "scripts": {
     "compile": "rm -rf ./target/ && tsc",
     "test": "npm run compile && node ./target/tests.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { ParsedUrlQuery } from 'querystring';
 import * as urlHelpers from 'url';
 import { UrlObject, UrlWithParsedQuery, UrlWithStringQuery } from 'url';
 import { getOrElseMaybe, mapMaybe } from './helpers/maybe';
@@ -32,10 +31,11 @@ const mapUrlWithParsedQuery = (fn: MapUrlWithParsedQueryFn) =>
         urlHelpers.format,
     );
 
+type ParsedUrlQueryInput = { [key: string]: unknown };
 const addQueryToParsedUrl = ({
     queryToAppend,
 }: {
-    queryToAppend: ParsedUrlQuery;
+    queryToAppend: ParsedUrlQueryInput;
 }): MapUrlWithParsedQueryFn => ({ parsedUrl }) => {
     const { auth, protocol, host, hash, pathname, query: existingQuery } = parsedUrl;
     const newQuery = { ...existingQuery, ...queryToAppend };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { ParsedUrlQuery } from 'querystring';
 import * as urlHelpers from 'url';
-import { UrlWithParsedQuery, UrlWithStringQuery } from 'url';
+import { UrlObject, UrlWithParsedQuery, UrlWithStringQuery } from 'url';
 import { getOrElseMaybe, mapMaybe } from './helpers/maybe';
 import { flipCurried, isNonEmptyString } from './helpers/other';
 import { pipe } from './helpers/pipe';
@@ -16,7 +16,7 @@ const parseUrlWithQueryString = (url: string) =>
         true,
     );
 
-type MapUrlFn = ({ parsedUrl }: { parsedUrl: UrlWithStringQuery }) => UrlWithStringQuery;
+type MapUrlFn = ({ parsedUrl }: { parsedUrl: UrlWithStringQuery }) => UrlObject;
 const mapUrl = (fn: MapUrlFn) =>
     pipe(
         ({ url }: { url: string }) => urlHelpers.parse(url),
@@ -24,9 +24,7 @@ const mapUrl = (fn: MapUrlFn) =>
         urlHelpers.format,
     );
 
-type MapUrlWithParsedQueryFn = (
-    { parsedUrl }: { parsedUrl: UrlWithParsedQuery },
-) => UrlWithParsedQuery;
+type MapUrlWithParsedQueryFn = ({ parsedUrl }: { parsedUrl: UrlWithParsedQuery }) => UrlObject;
 const mapUrlWithParsedQuery = (fn: MapUrlWithParsedQueryFn) =>
     pipe(
         ({ url }: { url: string }) => parseUrlWithQueryString(url),

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ const parseUrlWithQueryString = (url: string) =>
         true,
     );
 
-const mapUrl = (fn: ({ parsedUrl }: { parsedUrl: UrlWithStringQuery }) => UrlWithStringQuery) =>
+type MapUrlFn = ({ parsedUrl }: { parsedUrl: UrlWithStringQuery }) => UrlWithStringQuery;
+const mapUrl = (fn: MapUrlFn) =>
     pipe(
         ({ url }: { url: string }) => urlHelpers.parse(url),
         parsedUrl => fn({ parsedUrl }),
@@ -63,11 +64,7 @@ const parsePath = pipe(
     ({ search, pathname }) => ({ search, pathname }),
 );
 
-const replacePathInParsedUrl = ({ newPath }: { newPath: string }) => ({
-    parsedUrl,
-}: {
-    parsedUrl: UrlWithStringQuery;
-}) =>
+const replacePathInParsedUrl = ({ newPath }: { newPath: string }): MapUrlFn => ({ parsedUrl }) =>
     pipe(
         () => parsePath(newPath),
         newPathParsed => ({ ...parsedUrl, ...newPathParsed }),
@@ -80,10 +77,8 @@ export const replacePathInUrl = flipCurried(
     ),
 );
 
-const replacePathnameInParsedUrl = ({ newPathname }: { newPathname: string }) => ({
+const replacePathnameInParsedUrl = ({ newPathname }: { newPathname: string }): MapUrlFn => ({
     parsedUrl,
-}: {
-    parsedUrl: UrlWithStringQuery;
 }) => ({ ...parsedUrl, pathname: newPathname });
 
 export const replacePathnameInUrl = flipCurried(
@@ -93,11 +88,11 @@ export const replacePathnameInUrl = flipCurried(
     ),
 );
 
-const appendPathnameToParsedUrl = ({ pathnameToAppend }: { pathnameToAppend: string }) => ({
-    parsedUrl,
+const appendPathnameToParsedUrl = ({
+    pathnameToAppend,
 }: {
-    parsedUrl: UrlWithStringQuery;
-}) => {
+    pathnameToAppend: string;
+}): MapUrlFn => ({ parsedUrl }) => {
     const pathnameParts = pipe(
         () => mapMaybe(parsedUrl.pathname, getPartsFromPathname),
         maybe => getOrElseMaybe(maybe, () => []),
@@ -115,10 +110,8 @@ export const appendPathnameToUrl = flipCurried(
     ),
 );
 
-const replaceHashInParsedUrl = ({ newHash }: { newHash: string | undefined }) => ({
+const replaceHashInParsedUrl = ({ newHash }: { newHash: string | undefined }): MapUrlFn => ({
     parsedUrl,
-}: {
-    parsedUrl: UrlWithStringQuery;
 }) => ({
     ...parsedUrl,
     hash: newHash,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,20 +23,21 @@ const mapUrl = (fn: ({ parsedUrl }: { parsedUrl: UrlWithStringQuery }) => UrlWit
         urlHelpers.format,
     );
 
-const mapUrlWithParsedQuery = (
-    fn: ({ parsedUrl }: { parsedUrl: UrlWithParsedQuery }) => UrlWithParsedQuery,
-) =>
+type MapUrlWithParsedQueryFn = (
+    { parsedUrl }: { parsedUrl: UrlWithParsedQuery },
+) => UrlWithParsedQuery;
+const mapUrlWithParsedQuery = (fn: MapUrlWithParsedQueryFn) =>
     pipe(
         ({ url }: { url: string }) => parseUrlWithQueryString(url),
         parsedUrl => fn({ parsedUrl }),
         urlHelpers.format,
     );
 
-const addQueryToParsedUrl = ({ queryToAppend }: { queryToAppend: ParsedUrlQuery }) => ({
-    parsedUrl,
+const addQueryToParsedUrl = ({
+    queryToAppend,
 }: {
-    parsedUrl: UrlWithParsedQuery;
-}): UrlWithParsedQuery => {
+    queryToAppend: ParsedUrlQuery;
+}): MapUrlWithParsedQueryFn => ({ parsedUrl }) => {
     const { auth, protocol, host, hash, pathname, query: existingQuery } = parsedUrl;
     const newQuery = { ...existingQuery, ...queryToAppend };
     const newParsedUrl = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const getPathnameFromParts = (parts: string[]) => `/${parts.join('/')}`;
 
 const getPartsFromPathname = (pathname: string) => pathname.split('/').filter(isNonEmptyString);
 
-const parseUrlWithQueryString = (url: string): UrlWithParsedQuery =>
+const parseUrlWithQueryString = (url: string) =>
     urlHelpers.parse(
         url,
         // Parse the query string

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ const mapUrlWithParsedQuery = (fn: MapUrlWithParsedQueryFn) =>
         urlHelpers.format,
     );
 
+// Note: if/when this PR is merged, this type will be available via the Node types.
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33997
 type ParsedUrlQueryInput = { [key: string]: unknown };
 const addQueryToParsedUrl = ({
     queryToAppend,

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -8,8 +8,15 @@ import {
 } from './index';
 
 assert.strictEqual(
-    addQueryToUrl({ url: 'http://foo.com/' })({ queryToAppend: { a: 'b', number: 1 } }),
-    'http://foo.com/?a=b&number=1',
+    addQueryToUrl({ url: 'http://foo.com/' })({
+        queryToAppend: {
+            string: 'string',
+            number: 1,
+            boolean: true,
+            strings: ['string1', 'string2'],
+        },
+    }),
+    'http://foo.com/?string=string&number=1&boolean=true&strings=string1&strings=string2',
 );
 assert.strictEqual(
     addQueryToUrl({ url: 'http://foo:bar@baz.com/' })({

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -8,8 +8,8 @@ import {
 } from './index';
 
 assert.strictEqual(
-    addQueryToUrl({ url: 'http://foo.com/' })({ queryToAppend: { a: 'b' } }),
-    'http://foo.com/?a=b',
+    addQueryToUrl({ url: 'http://foo.com/' })({ queryToAppend: { a: 'b', number: 1 } }),
+    'http://foo.com/?a=b&number=1',
 );
 assert.strictEqual(
     addQueryToUrl({ url: 'http://foo:bar@baz.com/' })({


### PR DESCRIPTION
Allows query param values to be any type, not just `string | string[]`.