### PR TITLE
Use `monocle-ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ yarn add url-transformers
 npm install url-transformers
 ```
 
+## Dependencies
+
+This project depends on [`monocle-ts`](https://github.com/gcanti/monocle-ts) (lenses library) and [`fp-ts`](https://github.com/gcanti/fp-ts). If tree shaking is used (via the `module` field in `package.json`) these dependencies will have a neglible impact on the bundle size—at the time of writing they only contribute ~500 bytes (gzipped) to the bundle.
+
 ## Development
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@types/node": "^14.14.16",
-    "fp-ts": "^2.9.1",
+    "fp-ts": "^2.9.2",
     "monocle-ts": "^2.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@types/node": "^14.14.16",
+    "fp-ts": "^2.9.1",
     "monocle-ts": "^2.3.3",
     "pipe-ts": "^0.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "version": "0.0.9",
   "scripts": {
-    "compile": "rm -rf ./dist/ && tsc -p ./tsconfig.json && tsc -p ./tsconfig.es6.json",
+    "compile": "rm -rf ./dist/ && tsc -p ./tsconfig.json && tsc -p ./tsconfig.es6.json && import-path-rewrite",
     "test": "npm run compile && node --require source-map-support/register ./dist/lib/tests.js",
     "format": "prettier --write './**/*.{ts,js,json,md}' '.prettierrc'",
     "prepublishOnly": "npm run compile"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pipe-ts": "^0.0.9"
   },
   "devDependencies": {
+    "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "prettier": "^2.2.1",
     "source-map-support": "^0.5.19",
     "typescript": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "dependencies": {
     "@types/node": "^14.14.16",
     "fp-ts": "^2.9.1",
-    "monocle-ts": "^2.3.3",
-    "pipe-ts": "^0.0.9"
+    "monocle-ts": "^2.3.3"
   },
   "devDependencies": {
     "import-path-rewrite": "github:gcanti/import-path-rewrite",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@types/node": "^14.14.16",
+    "monocle-ts": "^2.3.3",
     "pipe-ts": "^0.0.9"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,9 @@ export const mapParsedUrl = (fn: MapParsedUrlFn): MapParsedUrlFn => fn;
 type MapUrlFn = (url: string) => string;
 export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => pipe(urlCodec.decode, fn, urlCodec.encode);
 
-export const replaceQueryInParsedUrl = pipeWith(urlLens, L.prop('query'), lensModifyOrSet);
+const queryLens: L.Lens<ParsedUrl, ParsedUrl['query']> = pipeWith(urlLens, L.prop('query'));
+
+export const replaceQueryInParsedUrl = pipeWith(queryLens, lensModifyOrSet);
 
 export const replaceQueryInUrl = pipe(replaceQueryInParsedUrl, mapUrl);
 
@@ -148,6 +150,8 @@ export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUr
 
 export const appendPathnameToUrl = pipe(appendPathnameToParsedUrl, mapUrl);
 
-export const replaceHashInParsedUrl = pipeWith(urlLens, L.prop('hash'), lensModifyOrSet);
+const hashLens: L.Lens<ParsedUrl, ParsedUrl['hash']> = pipeWith(urlLens, L.prop('hash'));
+
+export const replaceHashInParsedUrl = pipeWith(hashLens, lensModifyOrSet);
 
 export const replaceHashInUrl = pipe(replaceHashInParsedUrl, mapUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ interface ParsedUrl
         >
     > {}
 
-const urlLens = L.id<ParsedUrl>();
+export const urlLens = L.id<ParsedUrl>();
 
 const lensModifyOrSet = <S, A>(sa: L.Lens<S, A>) => (f: A | ((a: A) => A)) =>
     // TODO: typeof f === 'function' - errors
@@ -78,7 +78,7 @@ export const mapParsedUrl = (fn: MapParsedUrlFn): MapParsedUrlFn => fn;
 type MapUrlFn = (url: string) => string;
 export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => pipe(urlCodec.decode, fn, urlCodec.encode);
 
-const queryLens: L.Lens<ParsedUrl, ParsedUrl['query']> = pipeWith(urlLens, L.prop('query'));
+export const queryLens: L.Lens<ParsedUrl, ParsedUrl['query']> = pipeWith(urlLens, L.prop('query'));
 
 export const replaceQueryInParsedUrl = pipeWith(queryLens, lensModifyOrSet);
 
@@ -91,7 +91,10 @@ export const addQueryToUrl = pipe(addQueryToParsedUrl, mapUrl);
 
 interface ParsedPath extends Pick<ParsedUrl, 'query' | 'pathname'> {}
 
-const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(urlLens, L.props('pathname', 'query'));
+export const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(
+    urlLens,
+    L.props('pathname', 'query'),
+);
 
 const parsePath = pipe(parseUrlWithQueryString, pathLens.get);
 
@@ -126,7 +129,7 @@ export const replacePathInUrl = pipe(
     mapUrl,
 );
 
-const pathnameLens: L.Lens<ParsedUrl, ParsedUrl['pathname']> = pipeWith(
+export const pathnameLens: L.Lens<ParsedUrl, ParsedUrl['pathname']> = pipeWith(
     urlLens,
     L.prop('pathname'),
 );
@@ -150,7 +153,7 @@ export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUr
 
 export const appendPathnameToUrl = pipe(appendPathnameToParsedUrl, mapUrl);
 
-const hashLens: L.Lens<ParsedUrl, ParsedUrl['hash']> = pipeWith(urlLens, L.prop('hash'));
+export const hashLens: L.Lens<ParsedUrl, ParsedUrl['hash']> = pipeWith(urlLens, L.prop('hash'));
 
 export const replaceHashInParsedUrl = pipeWith(hashLens, lensModifyOrSet);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ interface ParsedUrl
 
 const baseLens = L.id<ParsedUrl>();
 
-const lensModifyOrSet = <A>(f: A | ((a: A) => A)) => <S>(sa: L.Lens<S, A>) =>
+const lensModifyOrSet = <S, A>(sa: L.Lens<S, A>) => (f: A | ((a: A) => A)) =>
     // TODO: typeof f === 'function' - errors
     f instanceof Function ? pipeWith(sa, L.modify(f)) : sa.set(f);
 
@@ -78,8 +78,7 @@ export const mapParsedUrl = (fn: MapParsedUrlFn): MapParsedUrlFn => fn;
 type MapUrlFn = (url: string) => string;
 export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => pipe(urlCodec.decode, fn, urlCodec.encode);
 
-export const replaceQueryInParsedUrl = (newQuery: Update<ParsedUrl['query']>): MapParsedUrlFn =>
-    pipeWith(baseLens, L.prop('query'), lensModifyOrSet(newQuery));
+export const replaceQueryInParsedUrl = pipeWith(baseLens, L.prop('query'), lensModifyOrSet);
 
 export const replaceQueryInUrl = pipe(replaceQueryInParsedUrl, mapUrl);
 
@@ -118,8 +117,11 @@ const convertUpdatePathToUpdateParsedPath = (newPath: Update<Path>): Update<Pars
         ? convertUpdatePathFnToUpdateParsedPathFn(newPath)
         : parseNullablePath(newPath);
 
-export const replacePathInParsedUrl = (newPath: Update<ParsedPath>): MapParsedUrlFn =>
-    pipeWith(baseLens, L.props('pathname', 'query'), lensModifyOrSet(newPath));
+export const replacePathInParsedUrl = pipeWith(
+    baseLens,
+    L.props('pathname', 'query'),
+    lensModifyOrSet,
+);
 
 export const replacePathInUrl = pipe(
     convertUpdatePathToUpdateParsedPath,
@@ -127,9 +129,7 @@ export const replacePathInUrl = pipe(
     mapUrl,
 );
 
-export const replacePathnameInParsedUrl = (
-    newPathname: Update<ParsedUrl['pathname']>,
-): MapParsedUrlFn => pipeWith(baseLens, L.prop('pathname'), lensModifyOrSet(newPathname));
+export const replacePathnameInParsedUrl = pipeWith(baseLens, L.prop('pathname'), lensModifyOrSet);
 
 export const replacePathnameInUrl = pipe(replacePathnameInParsedUrl, mapUrl);
 
@@ -148,7 +148,6 @@ export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUr
 
 export const appendPathnameToUrl = pipe(appendPathnameToParsedUrl, mapUrl);
 
-export const replaceHashInParsedUrl = (newHash: Update<ParsedUrl['hash']>): MapParsedUrlFn =>
-    pipeWith(baseLens, L.prop('hash'), lensModifyOrSet(newHash));
+export const replaceHashInParsedUrl = pipeWith(baseLens, L.prop('hash'), lensModifyOrSet);
 
 export const replaceHashInUrl = pipe(replaceHashInParsedUrl, mapUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
+import { flow, pipe } from 'fp-ts/lib/function';
 import * as L from 'monocle-ts/lib/Lens';
-// TODO: remove now we have fp-ts (peer dep)
-import { pipe, pipeWith } from 'pipe-ts';
 import { ParsedUrlQueryInput } from 'querystring';
 import * as urlHelpers from 'url';
 import { getOrElseMaybe, mapMaybe } from './helpers/maybe';
@@ -37,7 +36,7 @@ export const urlLens = L.id<ParsedUrl>();
 
 const lensModifyOrSet = <S, A>(sa: L.Lens<S, A>) => (f: A | ((a: A) => A)) =>
     // TODO: typeof f === 'function' - errors
-    f instanceof Function ? pipeWith(sa, L.modify(f)) : sa.set(f);
+    f instanceof Function ? pipe(sa, L.modify(f)) : sa.set(f);
 
 const convertNodeUrl = ({
     auth,
@@ -59,7 +58,7 @@ const convertNodeUrl = ({
     slashes,
 });
 
-const parseUrl = pipe(parseUrlWithQueryString, convertNodeUrl);
+const parseUrl = flow(parseUrlWithQueryString, convertNodeUrl);
 const formatUrl = (parsedUrl: ParsedUrl) => urlHelpers.format(parsedUrl);
 
 type Codec<A, IO> = {
@@ -76,29 +75,26 @@ type MapParsedUrlFn = (parsedUrl: ParsedUrl) => ParsedUrl;
 export const mapParsedUrl = (fn: MapParsedUrlFn): MapParsedUrlFn => fn;
 
 type MapUrlFn = (url: string) => string;
-export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => pipe(urlCodec.decode, fn, urlCodec.encode);
+export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => flow(urlCodec.decode, fn, urlCodec.encode);
 
-export const queryLens: L.Lens<ParsedUrl, ParsedUrl['query']> = pipeWith(urlLens, L.prop('query'));
+export const queryLens: L.Lens<ParsedUrl, ParsedUrl['query']> = pipe(urlLens, L.prop('query'));
 
-export const replaceQueryInParsedUrl = pipeWith(queryLens, lensModifyOrSet);
+export const replaceQueryInParsedUrl = pipe(queryLens, lensModifyOrSet);
 
-export const replaceQueryInUrl = pipe(replaceQueryInParsedUrl, mapUrl);
+export const replaceQueryInUrl = flow(replaceQueryInParsedUrl, mapUrl);
 
 export const addQueryToParsedUrl = (queryToAppend: ParsedUrl['query']): MapParsedUrlFn =>
     replaceQueryInParsedUrl((prevQuery) => ({ ...prevQuery, ...queryToAppend }));
 
-export const addQueryToUrl = pipe(addQueryToParsedUrl, mapUrl);
+export const addQueryToUrl = flow(addQueryToParsedUrl, mapUrl);
 
 interface ParsedPath extends Pick<ParsedUrl, 'query' | 'pathname'> {}
 
-export const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(
-    urlLens,
-    L.props('pathname', 'query'),
-);
+export const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipe(urlLens, L.props('pathname', 'query'));
 
-const parsePath = pipe(parseUrlWithQueryString, pathLens.get);
+const parsePath = flow(parseUrlWithQueryString, pathLens.get);
 
-const parseNullablePath = pipe(
+const parseNullablePath = flow(
     mapMaybe(parsePath),
     getOrElseMaybe((): ParsedPath => ({ query: null, pathname: null })),
 );
@@ -114,33 +110,33 @@ const pathCodec: Codec<ParsedPath, Path> = {
 
 const convertUpdatePathFnToUpdateParsedPathFn = (
     updatePath: UpdateFn<Path>,
-): UpdateFn<ParsedPath> => pipe(pathCodec.encode, updatePath, pathCodec.decode);
+): UpdateFn<ParsedPath> => flow(pathCodec.encode, updatePath, pathCodec.decode);
 
 const convertUpdatePathToUpdateParsedPath = (newPath: Update<Path>): Update<ParsedPath> =>
     typeof newPath === 'function'
         ? convertUpdatePathFnToUpdateParsedPathFn(newPath)
         : parseNullablePath(newPath);
 
-export const replacePathInParsedUrl = pipeWith(pathLens, lensModifyOrSet);
+export const replacePathInParsedUrl = pipe(pathLens, lensModifyOrSet);
 
-export const replacePathInUrl = pipe(
+export const replacePathInUrl = flow(
     convertUpdatePathToUpdateParsedPath,
     replacePathInParsedUrl,
     mapUrl,
 );
 
-export const pathnameLens: L.Lens<ParsedUrl, ParsedUrl['pathname']> = pipeWith(
+export const pathnameLens: L.Lens<ParsedUrl, ParsedUrl['pathname']> = pipe(
     urlLens,
     L.prop('pathname'),
 );
 
-export const replacePathnameInParsedUrl = pipeWith(pathnameLens, lensModifyOrSet);
+export const replacePathnameInParsedUrl = pipe(pathnameLens, lensModifyOrSet);
 
-export const replacePathnameInUrl = pipe(replacePathnameInParsedUrl, mapUrl);
+export const replacePathnameInUrl = flow(replacePathnameInParsedUrl, mapUrl);
 
 export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUrlFn =>
     replacePathnameInParsedUrl((prevPathname) => {
-        const pathnameParts = pipeWith(
+        const pathnameParts = pipe(
             prevPathname,
             mapMaybe(getPartsFromPathname),
             getOrElseMaybe((): string[] => []),
@@ -151,10 +147,10 @@ export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUr
         return newPathname;
     });
 
-export const appendPathnameToUrl = pipe(appendPathnameToParsedUrl, mapUrl);
+export const appendPathnameToUrl = flow(appendPathnameToParsedUrl, mapUrl);
 
-export const hashLens: L.Lens<ParsedUrl, ParsedUrl['hash']> = pipeWith(urlLens, L.prop('hash'));
+export const hashLens: L.Lens<ParsedUrl, ParsedUrl['hash']> = pipe(urlLens, L.prop('hash'));
 
-export const replaceHashInParsedUrl = pipeWith(hashLens, lensModifyOrSet);
+export const replaceHashInParsedUrl = pipe(hashLens, lensModifyOrSet);
 
-export const replaceHashInUrl = pipe(replaceHashInParsedUrl, mapUrl);
+export const replaceHashInUrl = flow(replaceHashInParsedUrl, mapUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ interface ParsedUrl
 
 const baseLens = L.id<ParsedUrl>();
 
+const lensModifyOrSet = <A>(f: A | ((a: A) => A)) => <S>(sa: L.Lens<S, A>) =>
+    // TODO: typeof f === 'function' - errors
+    f instanceof Function ? pipeWith(sa, L.modify(f)) : sa.set(f);
+
 const convertNodeUrl = ({
     auth,
     hash,
@@ -75,11 +79,7 @@ type MapUrlFn = (url: string) => string;
 export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => pipe(urlCodec.decode, fn, urlCodec.encode);
 
 export const replaceQueryInParsedUrl = (newQuery: Update<ParsedUrl['query']>): MapParsedUrlFn =>
-    pipeWith(
-        baseLens,
-        L.prop('query'),
-        L.modify((prev) => (typeof newQuery === 'function' ? newQuery(prev) : newQuery)),
-    );
+    pipeWith(baseLens, L.prop('query'), lensModifyOrSet(newQuery));
 
 export const replaceQueryInUrl = pipe(replaceQueryInParsedUrl, mapUrl);
 
@@ -119,11 +119,7 @@ const convertUpdatePathToUpdateParsedPath = (newPath: Update<Path>): Update<Pars
         : parseNullablePath(newPath);
 
 export const replacePathInParsedUrl = (newPath: Update<ParsedPath>): MapParsedUrlFn =>
-    pipeWith(
-        baseLens,
-        L.props('pathname', 'query'),
-        L.modify((prev) => (typeof newPath === 'function' ? newPath(prev) : newPath)),
-    );
+    pipeWith(baseLens, L.props('pathname', 'query'), lensModifyOrSet(newPath));
 
 export const replacePathInUrl = pipe(
     convertUpdatePathToUpdateParsedPath,
@@ -133,12 +129,7 @@ export const replacePathInUrl = pipe(
 
 export const replacePathnameInParsedUrl = (
     newPathname: Update<ParsedUrl['pathname']>,
-): MapParsedUrlFn =>
-    pipeWith(
-        baseLens,
-        L.prop('pathname'),
-        L.modify((prev) => (typeof newPathname === 'function' ? newPathname(prev) : newPathname)),
-    );
+): MapParsedUrlFn => pipeWith(baseLens, L.prop('pathname'), lensModifyOrSet(newPathname));
 
 export const replacePathnameInUrl = pipe(replacePathnameInParsedUrl, mapUrl);
 
@@ -158,10 +149,6 @@ export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUr
 export const appendPathnameToUrl = pipe(appendPathnameToParsedUrl, mapUrl);
 
 export const replaceHashInParsedUrl = (newHash: Update<ParsedUrl['hash']>): MapParsedUrlFn =>
-    pipeWith(
-        baseLens,
-        L.prop('hash'),
-        L.modify((prev) => (typeof newHash === 'function' ? newHash(prev) : newHash)),
-    );
+    pipeWith(baseLens, L.prop('hash'), lensModifyOrSet(newHash));
 
 export const replaceHashInUrl = pipe(replaceHashInParsedUrl, mapUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,11 +117,9 @@ const convertUpdatePathToUpdateParsedPath = (newPath: Update<Path>): Update<Pars
         ? convertUpdatePathFnToUpdateParsedPathFn(newPath)
         : parseNullablePath(newPath);
 
-export const replacePathInParsedUrl = pipeWith(
-    baseLens,
-    L.props('pathname', 'query'),
-    lensModifyOrSet,
-);
+const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(baseLens, L.props('pathname', 'query'));
+
+export const replacePathInParsedUrl = pipeWith(pathLens, lensModifyOrSet);
 
 export const replacePathInUrl = pipe(
     convertUpdatePathToUpdateParsedPath,
@@ -129,7 +127,12 @@ export const replacePathInUrl = pipe(
     mapUrl,
 );
 
-export const replacePathnameInParsedUrl = pipeWith(baseLens, L.prop('pathname'), lensModifyOrSet);
+const pathnameLens: L.Lens<ParsedUrl, ParsedUrl['pathname']> = pipeWith(
+    baseLens,
+    L.prop('pathname'),
+);
+
+export const replacePathnameInParsedUrl = pipeWith(pathnameLens, lensModifyOrSet);
 
 export const replacePathnameInUrl = pipe(replacePathnameInParsedUrl, mapUrl);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ interface ParsedUrl
         >
     > {}
 
-const baseLens = L.id<ParsedUrl>();
+const urlLens = L.id<ParsedUrl>();
 
 const lensModifyOrSet = <S, A>(sa: L.Lens<S, A>) => (f: A | ((a: A) => A)) =>
     // TODO: typeof f === 'function' - errors
@@ -78,7 +78,7 @@ export const mapParsedUrl = (fn: MapParsedUrlFn): MapParsedUrlFn => fn;
 type MapUrlFn = (url: string) => string;
 export const mapUrl = (fn: MapParsedUrlFn): MapUrlFn => pipe(urlCodec.decode, fn, urlCodec.encode);
 
-export const replaceQueryInParsedUrl = pipeWith(baseLens, L.prop('query'), lensModifyOrSet);
+export const replaceQueryInParsedUrl = pipeWith(urlLens, L.prop('query'), lensModifyOrSet);
 
 export const replaceQueryInUrl = pipe(replaceQueryInParsedUrl, mapUrl);
 
@@ -117,7 +117,7 @@ const convertUpdatePathToUpdateParsedPath = (newPath: Update<Path>): Update<Pars
         ? convertUpdatePathFnToUpdateParsedPathFn(newPath)
         : parseNullablePath(newPath);
 
-const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(baseLens, L.props('pathname', 'query'));
+const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(urlLens, L.props('pathname', 'query'));
 
 export const replacePathInParsedUrl = pipeWith(pathLens, lensModifyOrSet);
 
@@ -128,7 +128,7 @@ export const replacePathInUrl = pipe(
 );
 
 const pathnameLens: L.Lens<ParsedUrl, ParsedUrl['pathname']> = pipeWith(
-    baseLens,
+    urlLens,
     L.prop('pathname'),
 );
 
@@ -151,6 +151,6 @@ export const appendPathnameToParsedUrl = (pathnameToAppend: string): MapParsedUr
 
 export const appendPathnameToUrl = pipe(appendPathnameToParsedUrl, mapUrl);
 
-export const replaceHashInParsedUrl = pipeWith(baseLens, L.prop('hash'), lensModifyOrSet);
+export const replaceHashInParsedUrl = pipeWith(urlLens, L.prop('hash'), lensModifyOrSet);
 
 export const replaceHashInUrl = pipe(replaceHashInParsedUrl, mapUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ interface ParsedUrl
 export const urlLens = L.id<ParsedUrl>();
 
 const lensModifyOrSet = <S, A>(sa: L.Lens<S, A>) => (f: A | ((a: A) => A)) =>
-    // TODO: typeof f === 'function' - errors
     f instanceof Function ? pipe(sa, L.modify(f)) : sa.set(f);
 
 const convertNodeUrl = ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,10 +89,9 @@ export const addQueryToUrl = pipe(addQueryToParsedUrl, mapUrl);
 
 interface ParsedPath extends Pick<ParsedUrl, 'query' | 'pathname'> {}
 
-const parsePath = pipe(
-    parseUrlWithQueryString,
-    ({ query, pathname }): ParsedPath => ({ query, pathname }),
-);
+const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(urlLens, L.props('pathname', 'query'));
+
+const parsePath = pipe(parseUrlWithQueryString, pathLens.get);
 
 const parseNullablePath = pipe(
     mapMaybe(parsePath),
@@ -116,8 +115,6 @@ const convertUpdatePathToUpdateParsedPath = (newPath: Update<Path>): Update<Pars
     typeof newPath === 'function'
         ? convertUpdatePathFnToUpdateParsedPathFn(newPath)
         : parseNullablePath(newPath);
-
-const pathLens: L.Lens<ParsedUrl, ParsedPath> = pipeWith(urlLens, L.props('pathname', 'query'));
 
 export const replacePathInParsedUrl = pipeWith(pathLens, lensModifyOrSet);
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { pipe, pipeWith } from 'pipe-ts';
+import { flow, pipe } from 'fp-ts/lib/function';
 import * as urlHelpers from 'url';
 import {
     addQueryToUrl,
@@ -16,7 +16,7 @@ import {
 } from './index';
 
 assert.deepEqual(
-    pipeWith(
+    pipe(
         urlHelpers.parse('https://foo.com/bar', true),
         mapParsedUrl((parsedUrl) => ({
             ...parsedUrl,
@@ -29,7 +29,7 @@ assert.deepEqual(
 );
 
 assert.deepEqual(
-    pipeWith(
+    pipe(
         'https://foo.com/bar',
         mapUrl((parsedUrl) => ({
             ...parsedUrl,
@@ -41,10 +41,10 @@ assert.deepEqual(
 );
 
 assert.deepEqual(
-    pipeWith(
+    pipe(
         'https://foo.com/bar',
         mapUrl(
-            pipe(
+            flow(
                 replacePathnameInParsedUrl(() => '/foo'),
                 replaceQueryInParsedUrl(() => ({ a: 'b' })),
             ),
@@ -92,7 +92,7 @@ assert.strictEqual(
 );
 
 assert.strictEqual(
-    pipeWith(
+    pipe(
         'https://foo.com/foo?example',
         mapUrl(
             replacePathInParsedUrl((prev) => ({ pathname: `${prev.pathname}/bar`, query: null })),
@@ -101,7 +101,7 @@ assert.strictEqual(
     'https://foo.com/foo/bar',
 );
 assert.strictEqual(
-    pipeWith(
+    pipe(
         'https://foo.com/foo?example',
         mapUrl(
             replacePathInParsedUrl((prev) => ({
@@ -113,7 +113,7 @@ assert.strictEqual(
     'https://foo.com/foo/bar?example=',
 );
 assert.strictEqual(
-    pipeWith(
+    pipe(
         'https://foo.com/foo?example',
         mapUrl(replacePathInParsedUrl({ pathname: null, query: null })),
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,20 +7,126 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.16.tgz#3cc351f8d48101deadfed4c9e4f116048d437b4b"
   integrity sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==
 
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 fp-ts@^2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.9.1.tgz#24557f66f9221f8a1922fce6cbe2b8ea6d0f3929"
   integrity sha512-9++IpEtF2blK7tfSV+iHxO3KXdAGO/bPPQtUYqzC6XKzGOWNctqvlf13SpXxcu2mYaibOvneh/m9vAPLAHdoRQ==
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+"import-path-rewrite@github:gcanti/import-path-rewrite":
+  version "0.0.1"
+  resolved "https://codeload.github.com/gcanti/import-path-rewrite/tar.gz/39b4178f9ff80aed3fa18a702584e0d0f0d6d8bc"
+  dependencies:
+    chalk "^3.0.0"
+    glob "^7.1.6"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 monocle-ts@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.3.3.tgz#1e6d83dcf42bcb96b74fdda07813c2a47ec6cfa4"
   integrity sha512-pcQyauWO2vapxyZgbhTd73Dv8TmTELx1rL81bvrtPO2sUYTi1MIHmw3j/iMyeNaJwTmnGNAjqJpYV8Gq1Eu68g==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 pipe-ts@^0.0.9:
   version "0.0.9"
@@ -45,7 +151,19 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
 typescript@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,11 +128,6 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-pipe-ts@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/pipe-ts/-/pipe-ts-0.0.9.tgz#9c1c9856348e5eeb1250b4c6d291b776b55556ca"
-  integrity sha512-j5DfveOe0xC4hIK6/FRJ+zHjvrgbMO+kgnM4ZsSQqWZZL8fgCYCAu7TXdkVLavX/2nALm32yBVDixW8+/aYtGA==
-
 prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+fp-ts@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.9.1.tgz#24557f66f9221f8a1922fce6cbe2b8ea6d0f3929"
+  integrity sha512-9++IpEtF2blK7tfSV+iHxO3KXdAGO/bPPQtUYqzC6XKzGOWNctqvlf13SpXxcu2mYaibOvneh/m9vAPLAHdoRQ==
+
 monocle-ts@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.3.3.tgz#1e6d83dcf42bcb96b74fdda07813c2a47ec6cfa4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+monocle-ts@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.3.3.tgz#1e6d83dcf42bcb96b74fdda07813c2a47ec6cfa4"
+  integrity sha512-pcQyauWO2vapxyZgbhTd73Dv8TmTELx1rL81bvrtPO2sUYTi1MIHmw3j/iMyeNaJwTmnGNAjqJpYV8Gq1Eu68g==
+
 pipe-ts@^0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/pipe-ts/-/pipe-ts-0.0.9.tgz#9c1c9856348e5eeb1250b4c6d291b776b55556ca"

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-fp-ts@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.9.1.tgz#24557f66f9221f8a1922fce6cbe2b8ea6d0f3929"
-  integrity sha512-9++IpEtF2blK7tfSV+iHxO3KXdAGO/bPPQtUYqzC6XKzGOWNctqvlf13SpXxcu2mYaibOvneh/m9vAPLAHdoRQ==
+fp-ts@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.9.2.tgz#0f51b6bdb52fe4314e96c93bb5f15a2969c562d9"
+  integrity sha512-fswVB9E5Aq9+jCZU+4heaJTYuv8m5/vn9ii12pmxduyf3YwP4AQKFmFO66YDNzL+c0iP6G8Cav5gpvc+2emOAw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Depends on #4, #5, https://github.com/unsplash/url-transformers/pull/14

webpack tree shaking test (gzip sizes):

- before: 5.85 kB (mostly `url` polyfill)
- after: 6.57 kB
- after some tree shaking fixes in fp-ts (https://github.com/gcanti/fp-ts/pull/1368): 6.26 kB