### PR TITLE
`replacePathInUrl`/`replacePathInParsedUrl`: use path not pathname

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,9 @@ const parsePath = pipe(
     ({ query, pathname }): ParsedPath => ({ query, pathname }),
 );
 
-const parseNullablePath = (maybePath: Required<NodeUrlObjectWithParsedQuery>['path']): ParsedPath =>
+type Path = Required<NodeUrlObjectWithParsedQuery>['path'];
+
+const parseNullablePath = (maybePath: Path): ParsedPath =>
     pipeWith(
         maybePath,
         maybe => mapMaybe(maybe, parsePath),

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ const getParsedPathFromString = (maybePath: NodeUrlObjectWithParsedQuery['path']
     );
 
 export const replacePathInParsedUrl = (
-    newPath: Update<NodeUrlObjectWithParsedQuery['path']>,
+    newPath: Update<NodeUrlObjectWithParsedQuery['pathname']>,
 ): MapParsedUrlFn => parsedUrl =>
     pipeWith(
         newPath instanceof Function ? newPath(parsedUrl.pathname) : newPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ const parsePath = pipe(
     ({ query, pathname }): ParsedPath => ({ query, pathname }),
 );
 
-const parseNullablePath = (maybePath: NodeUrlObjectWithParsedQuery['path']): ParsedPath =>
+const parseNullablePath = (maybePath: Required<NodeUrlObjectWithParsedQuery>['path']): ParsedPath =>
     pipeWith(
         maybePath,
         maybe => mapMaybe(maybe, parsePath),
@@ -97,7 +97,7 @@ const parseNullablePath = (maybePath: NodeUrlObjectWithParsedQuery['path']): Par
     );
 
 export const replacePathInParsedUrl = (
-    newPath: Update<NodeUrlObjectWithParsedQuery['pathname']>,
+    newPath: Update<ParsedUrl['pathname']>,
 ): MapParsedUrlFn => parsedUrl =>
     pipeWith(
         newPath instanceof Function ? newPath(parsedUrl.pathname) : newPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ interface NodeUrlObjectWithParsedQuery extends urlHelpers.UrlObject {
     query?: ParsedUrlQueryInput | null;
 }
 
-type Update<T> = T | ((prev: T) => T);
+type UpdateFn<T> = (prev: T) => T;
+type Update<T> = T | UpdateFn<T>;
 
 const getPathnameFromParts = (parts: string[]) => `/${parts.join('/')}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export const addQueryToUrl = pipe(
 type ParsedPath = Pick<ParsedUrl, 'query' | 'pathname'>;
 
 const parsePath = pipe(
-    (path: string) => parseUrlWithQueryString(path),
+    parseUrlWithQueryString,
     ({ query, pathname }): ParsedPath => ({ query, pathname }),
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ const parsePath = pipe(
     ({ query, pathname }): ParsedPath => ({ query, pathname }),
 );
 
-const getParsedPathFromString = (maybePath: NodeUrlObjectWithParsedQuery['path']): ParsedPath =>
+const parseNullablePath = (maybePath: NodeUrlObjectWithParsedQuery['path']): ParsedPath =>
     pipeWith(
         maybePath,
         maybe => mapMaybe(maybe, parsePath),
@@ -101,7 +101,7 @@ export const replacePathInParsedUrl = (
 ): MapParsedUrlFn => parsedUrl =>
     pipeWith(
         newPath instanceof Function ? newPath(parsedUrl.pathname) : newPath,
-        getParsedPathFromString,
+        parseNullablePath,
         newPathParsed => ({ ...parsedUrl, ...newPathParsed }),
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { getOrElseMaybe, mapMaybe } from './helpers/maybe';
 import { isNonEmptyString } from './helpers/other';
 
 interface NodeUrlObjectWithParsedQuery extends urlHelpers.UrlObject {
-    query: ParsedUrlQueryInput;
+    query?: ParsedUrlQueryInput | null;
 }
 
 type Update<T> = T | ((prev: T) => T);

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -7,6 +7,7 @@ import {
     mapParsedUrl,
     mapUrl,
     replaceHashInUrl,
+    replacePathInParsedUrl,
     replacePathInUrl,
     replacePathnameInParsedUrl,
     replacePathnameInUrl,
@@ -90,6 +91,41 @@ assert.strictEqual(
     'http://foo.com/?a=b&b=c&c=d',
 );
 
+assert.strictEqual(
+    pipeWith(
+        'https://foo.com/foo?example',
+        mapUrl(replacePathInParsedUrl(prev => ({ pathname: `${prev.pathname}/bar`, query: null }))),
+    ),
+    'https://foo.com/foo/bar',
+);
+assert.strictEqual(
+    pipeWith(
+        'https://foo.com/foo?example',
+        mapUrl(
+            replacePathInParsedUrl(prev => ({
+                pathname: `${prev.pathname}/bar`,
+                query: prev.query,
+            })),
+        ),
+    ),
+    'https://foo.com/foo/bar?example=',
+);
+assert.strictEqual(
+    pipeWith(
+        'https://foo.com/foo?example',
+        mapUrl(replacePathInParsedUrl({ pathname: null, query: null })),
+    ),
+    'https://foo.com',
+);
+
+assert.strictEqual(
+    replacePathInUrl(prev => `${prev}/bar`)('https://foo.com/foo'),
+    'https://foo.com/foo/bar',
+);
+assert.strictEqual(
+    replacePathInUrl(prev => `${prev}/bar`)('https://foo.com/foo?example'),
+    'https://foo.com/foo?example=%2Fbar',
+);
 assert.strictEqual(replacePathInUrl('/bar')('https://foo.com/foo?example'), 'https://foo.com/bar');
 assert.strictEqual(replacePathInUrl(null)('https://foo.com/foo?example'), 'https://foo.com');
 


### PR DESCRIPTION
Fixes https://github.com/unsplash/url-transformers/issues/11